### PR TITLE
Fixes and dv dev

### DIFF
--- a/cmsver.sh
+++ b/cmsver.sh
@@ -3,55 +3,19 @@
 ########################################
 
 # Checking for WordPress, Joomla, Drupal, and phpBB installs and versions on a Media Temple Grid, Plesk 
-# and cPanel/WHM VPS
+# and cPanel/WHM VPS, and "DV Developer"
 
 ########################################
 
-# Exit the script if not run on a Media Temple Grid, Plesk, or cPanel VPS, or if not run using sudo/root on Plesk 
-# or cPanel
-function lost ()
+# Exit the script if not run using sudo/root on a VPS
+function bye ()
 {
 return 0
 }
 
-# Determine if working in a Grid, cPanel or Plesk server, then find all installs within a 
-# certain predefined number of sublevels respective to the server's webroot and add them to
-# a temporary file
-
-# If on a Grid
-if [[ ! -z "$SITE" ]]; then
-    find ~/domains/*/ -maxdepth 5 -iwholename "*/wp-includes/version.php" > ./wplist
-    find ~/domains/*/ -maxdepth 8 \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) > ./joomlalist
-    find ~/domains/*/ -maxdepth 6 -iwholename "*/modules/system/system.info" > ./drupallist
-    find ~/domains/*/ -maxdepth 6 -iwholename "*prosilver/style.cfg" > ./phpbblist
-# If on Plesk
-elif [[ -f "/usr/local/psa/version" ]]; then
-	if [ "$(id -u)" != "0" ]; then
-		echo "This should be run as root or sudo. Exiting..."
-		lost
-	else
-		find /var/www/vhosts/ -maxdepth 5 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o -iwholename "*/wp-includes/version.php" -print > ./wplist
-		find /var/www/vhosts/ -maxdepth 6 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) -print > ./joomlalist
-		find /var/www/vhosts/ -maxdepth 6 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o -iwholename "*/modules/system/system.info" -print > ./drupallist
-		find /var/www/vhosts/ -maxdepth 6 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o -iwholename "*prosilver/style.cfg" > ./phpbblist
-	fi	
-# If on cPanel
-elif [[ -f "/usr/local/cpanel/version" ]]; then
-	if [ "$(id -u)" != "0" ]; then
-		echo "This should be run as root or sudo. Exiting..."
-		lost
-	else
-		find /home/*/public_html/ -maxdepth 5 -iwholename "*/wp-includes/version.php" > ./wplist
-		find /home/*/public_html/ -maxdepth 6 \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) > ./joomlalist
-		find /home/*/public_html/ -maxdepth 6 -iwholename "*/modules/system/system.info" > ./drupallist
-		find /home/*/public_html/ -maxdepth 6 -iwholename "*prosilver/style.cfg" > ./phpbblist
-	fi
-else
-	echo "I can't determine the service I am on. Exiting..."
-	# see function at the beginning
-	lost
-fi
-
+# Doing the work
+function search ()
+{
 # If WordPress installs are found
 if [ -s ./wplist ]; then
 	# Get the latest version of WordPress.
@@ -236,3 +200,53 @@ fi
 
 # Delete all temporary lists
 rm ./wplist ./version_tmp ./drupallist ./joomlalist ./phpbblist 2> /dev/null
+}
+
+# Determine the server that the script is being run from, then find all installs within a 
+# certain predefined number of sublevels respective to the server's webroot and add them to
+# a temporary file
+
+# If on a Grid
+if [[ ! -z "$SITE" ]]; then
+    find ~/domains/*/ -maxdepth 5 -iwholename "*/wp-includes/version.php" > ./wplist
+    find ~/domains/*/ -maxdepth 6 \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) > ./joomlalist
+    find ~/domains/*/ -maxdepth 6 -iwholename "*/modules/system/system.info" > ./drupallist
+    find ~/domains/*/ -maxdepth 6 -iwholename "*prosilver/style.cfg" > ./phpbblist
+    search
+# If on Plesk
+elif [[ -f "/usr/local/psa/version" ]]; then
+	if [ "$(id -u)" != "0" ]; then
+		echo "This should be run as root or sudo. Exiting..."
+		bye
+	else
+		find /var/www/vhosts/ -maxdepth 5 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o -iwholename "*/wp-includes/version.php" -print > ./wplist
+		find /var/www/vhosts/ -maxdepth 6 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) -print > ./joomlalist
+		find /var/www/vhosts/ -maxdepth 6 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o -iwholename "*/modules/system/system.info" -print > ./drupallist
+		find /var/www/vhosts/ -maxdepth 6 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o -iwholename "*prosilver/style.cfg" -print > ./phpbblist
+		search
+	fi	
+# If on cPanel
+elif [[ -f "/usr/local/cpanel/version" ]]; then
+	if [ "$(id -u)" != "0" ]; then
+		echo "This should be run as root or sudo. Exiting..."
+		bye
+	else
+		find /home/*/public_html/ -maxdepth 5 -iwholename "*/wp-includes/version.php" > ./wplist
+		find /home/*/public_html/ -maxdepth 6 \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) > ./joomlalist
+		find /home/*/public_html/ -maxdepth 6 -iwholename "*/modules/system/system.info" > ./drupallist
+		find /home/*/public_html/ -maxdepth 6 -iwholename "*prosilver/style.cfg" > ./phpbblist
+		search
+	fi
+# If none of the above
+elif [[ ! -f "/usr/local/psa/version" ]] && [[ ! -f "/usr/local/cpanel/version" ]]; then
+	if [ "$(id -u)" != "0" ]; then
+		echo "This should be run as root or sudo. Exiting..."
+		bye
+	else 
+		find /var/www/ -maxdepth 6 -iwholename "*/wp-includes/version.php" > ./wplist
+    	find /var/www/ -maxdepth 7 \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) > ./joomlalist
+    	find /var/www/ -maxdepth 7 -iwholename "*/modules/system/system.info" > ./drupallist
+    	find /var/www/ -maxdepth 7 -iwholename "*prosilver/style.cfg" > ./phpbblist
+    	search
+	fi
+fi

--- a/cmsver.sh
+++ b/cmsver.sh
@@ -7,13 +7,12 @@
 
 ########################################
 
-# Exit the script if not run using sudo/root on a VPS
+# Exit the script if not being run by root or with sudo on a DV
 function bye ()
 {
-return 0
+	return 0
 }
 
-# Doing the work
 function search ()
 {
 # If WordPress installs are found
@@ -203,7 +202,7 @@ rm ./wplist ./version_tmp ./drupallist ./joomlalist ./phpbblist 2> /dev/null
 }
 
 # Determine the server that the script is being run from, then find all installs within a 
-# certain predefined number of sublevels respective to the server's webroot and add them to
+# certain predefined number of sublevels from the domains's webroot and add them to
 # a temporary file
 
 # If on a Grid
@@ -211,7 +210,7 @@ if [[ ! -z "$SITE" ]]; then
     find ~/domains/*/ -maxdepth 5 -iwholename "*/wp-includes/version.php" > ./wplist
     find ~/domains/*/ -maxdepth 6 \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) > ./joomlalist
     find ~/domains/*/ -maxdepth 6 -iwholename "*/modules/system/system.info" > ./drupallist
-    find ~/domains/*/ -maxdepth 6 -iwholename "*prosilver/style.cfg" > ./phpbblist
+    find ~/domains/*/ -maxdepth 5 -iwholename "*prosilver/style.cfg" > ./phpbblist
     search
 # If on Plesk
 elif [[ -f "/usr/local/psa/version" ]]; then
@@ -219,10 +218,11 @@ elif [[ -f "/usr/local/psa/version" ]]; then
 		echo "This should be run as root or sudo. Exiting..."
 		bye
 	else
-		find /var/www/vhosts/ -maxdepth 5 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o -iwholename "*/wp-includes/version.php" -print > ./wplist
-		find /var/www/vhosts/ -maxdepth 6 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) -print > ./joomlalist
-		find /var/www/vhosts/ -maxdepth 6 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o -iwholename "*/modules/system/system.info" -print > ./drupallist
-		find /var/www/vhosts/ -maxdepth 6 -type d \( -name chroot -o -name default -o -name logs -o -name error_docs -o -name fs -o -name fs-passwd -o -name ".skel" -o -name system \) -prune -o -iwholename "*prosilver/style.cfg" -print > ./phpbblist
+		paths=`/usr/local/psa/bin/domain --list | while read result; do /usr/local/psa/bin/domain --info $result; done | awk '/WWW-Root/ {print $2}'`
+		find $paths -maxdepth 5 -iwholename "*/wp-includes/version.php" > ./wplist
+		find $paths -maxdepth 6 \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) > ./joomlalist
+		find $paths -maxdepth 6 -iwholename "*/modules/system/system.info" > ./drupallist
+		find $paths -maxdepth 5 -iwholename "*prosilver/style.cfg" > ./phpbblist
 		search
 	fi	
 # If on cPanel
@@ -234,10 +234,10 @@ elif [[ -f "/usr/local/cpanel/version" ]]; then
 		find /home/*/public_html/ -maxdepth 5 -iwholename "*/wp-includes/version.php" > ./wplist
 		find /home/*/public_html/ -maxdepth 6 \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) > ./joomlalist
 		find /home/*/public_html/ -maxdepth 6 -iwholename "*/modules/system/system.info" > ./drupallist
-		find /home/*/public_html/ -maxdepth 6 -iwholename "*prosilver/style.cfg" > ./phpbblist
+		find /home/*/public_html/ -maxdepth 5 -iwholename "*prosilver/style.cfg" > ./phpbblist
 		search
 	fi
-# If none of the above
+# If none of the above, then  it's a DV Developer
 elif [[ ! -f "/usr/local/psa/version" ]] && [[ ! -f "/usr/local/cpanel/version" ]]; then
 	if [ "$(id -u)" != "0" ]; then
 		echo "This should be run as root or sudo. Exiting..."
@@ -246,7 +246,7 @@ elif [[ ! -f "/usr/local/psa/version" ]] && [[ ! -f "/usr/local/cpanel/version" 
 		find /var/www/ -maxdepth 6 -iwholename "*/wp-includes/version.php" > ./wplist
     	find /var/www/ -maxdepth 7 \( -iwholename '*/libraries/joomla/version.php' -o -iwholename '*/libraries/cms/version.php' -o -iwholename '*/libraries/cms/version/version.php' \) > ./joomlalist
     	find /var/www/ -maxdepth 7 -iwholename "*/modules/system/system.info" > ./drupallist
-    	find /var/www/ -maxdepth 7 -iwholename "*prosilver/style.cfg" > ./phpbblist
+    	find /var/www/ -maxdepth 6 -iwholename "*prosilver/style.cfg" > ./phpbblist
     	search
 	fi
 fi


### PR DESCRIPTION
-Renamed the function for "return 0" from "lost" to "bye" to generalize what it is doing
-I turned the entire process of working with the installs and the output into a function
-I moved the section that determines the server and searches for installs to the bottom
-I changed the path for a DV w/ Plesk from "/var/www/vhosts" to simply "/var/www/" so that it can be applied to DV Developers, rather than adding another section that would be almost exactly the same.
-I added a 1 second sleep between each CMS output because on servers with a large amount of CMS, output results would start combining in messy ways